### PR TITLE
Fix error handling when Campfire API doesn't return a proper date

### DIFF
--- a/bin/campfire_export
+++ b/bin/campfire_export
@@ -62,6 +62,7 @@ begin
       next
     end
 
+    puts "exporting room: #{room.name}"
     room.export(config_date(config, 'start_date'),
                 config_date(config, 'end_date'))
   end

--- a/bin/campfire_export
+++ b/bin/campfire_export
@@ -62,7 +62,6 @@ begin
       next
     end
 
-    puts "exporting room: #{room.name}"
     room.export(config_date(config, 'start_date'),
                 config_date(config, 'end_date'))
   end

--- a/lib/campfire_export/room.rb
+++ b/lib/campfire_export/room.rb
@@ -35,9 +35,9 @@ module CampfireExport
           @last_update = Account.timezone.utc_to_local(update_utc)
         rescue => e
           log(:error,
-              "couldn't get last update in #{room} (defaulting to today)",
+              "couldn't get last update in #{name} (defaulting to today)",
               e)
-          @last_update = Time.now
+          @last_update = Date.new()
         end
       end
   end


### PR DESCRIPTION
When the campfire API doesn't return a proper date for the last message in a room (probably because the room has no messages), the exception handler throws an error. There is no `room` attribute (should be `name`) and we want the current date, not time (so `Date.new()` instead of `Time.now()`.)
